### PR TITLE
add server code for a simple switch division puzzle

### DIFF
--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -11,6 +11,7 @@ import Puzzle1 from './puzzle1';
 import Puzzle2 from './puzzle2';
 import Puzzle3 from './puzzle3';
 import Puzzle4 from './puzzle4';
+import Puzzle5 from './puzzle5';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -47,7 +48,7 @@ export default class App extends React.Component {
           <Route path="/puzzle2" component={() => <Puzzle {...this.state} component={Puzzle2} />} />
           <Route path="/puzzle3" component={() => <Puzzle {...this.state} component={Puzzle3} />} />
           <Route path="/puzzle4" component={() => <Puzzle {...this.state} component={Puzzle4} />} />
-
+          <Route path="/puzzle5" component={() => <Puzzle {...this.state} component={Puzzle5} />} />
         </div>
         <hr />
         <h5>Testing Below</h5>

--- a/frontend/components/nav.jsx
+++ b/frontend/components/nav.jsx
@@ -27,6 +27,8 @@ const Nav = () => (
     <NavLink to='/puzzle3' >Puzzle 3</NavLink>
     <br/>
     <NavLink to='/puzzle4' >Puzzle 4</NavLink>
+    <br/>
+    <NavLink to='/puzzle5' >Puzzle 5</NavLink>
   </div>
 )
 

--- a/frontend/components/puzzle5.jsx
+++ b/frontend/components/puzzle5.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+class Puzzle5 extends React.Component {
+  constructor(props) {
+    super(props);
+
+    props.socket.on('puzzle5_join_response', (data) => {
+      this.setState({
+        switchIndex: data.switch_index,
+        total: data.total,
+       });
+    });
+    
+    props.send('puzzle5_join', {});
+
+    this.state = {
+      total: 0,
+      switchIndex: null,
+    }
+  }
+
+  render() {
+    const {
+      total,
+      switchIndex,
+    } = this.state;
+
+    const switches = [...Array(total).keys()].map((i) => {
+      return (
+        <div key={i}>
+          {i === switchIndex ? 'Y' : 'X'}
+        </div>
+      );
+    });
+
+    return (
+      <div>
+        <h1>Puzzle Five</h1>
+        {switches}
+      </div>
+    );
+  }
+};
+
+export default Puzzle5;

--- a/server/server.py
+++ b/server/server.py
@@ -4,17 +4,29 @@ import os
 import socketio
 import eventlet
 import eventlet.wsgi
+import random
 from flask import Flask, render_template, jsonify, request, send_from_directory
 
 sio = socketio.Server()
 flask_app = Flask(__name__)
 
 # { sid -> table number }
-clients = {}
+CLIENTS = {}
 # { table number -> { puzzle number -> { solved } } }
-game_state = {}
-answers = {
+GAME_STATE = {}
+INITIAL_GAME_STATE_FOR_TABLE = {
+  1: {'solved': False},
+  2: {'solved': False},
+  3: {'solved': False},
+  4: {'solved': False},
+  5: {'solved': False, 'segments': {}, 'total_segments': 0},
+}
+ANSWERS = {
   1: 'see o double you',
+  2: '',
+  3: '',
+  4: '',
+  5: '',
 }
 
 @flask_app.route('/')
@@ -29,33 +41,33 @@ def static_files(directory, filename):
 
 @sio.on('connect')
 def connect(sid, environ):
-  print "connect ", sid
+  print("connect ", sid)
 
 @sio.on('join')
 def join(sid, data):
   print("join", data, sid)
   table = data['table']
-  clients[sid] = table
+  CLIENTS[sid] = table
   sio.enter_room(sid, table)
-  if table in game_state:
+  if table in GAME_STATE:
     pass
     # TODO: broadcast when someone joins
   else:
-    game_state[table] = dict([(key, {'solved': False}) for key in answers])
-    sio.emit('game_state_update', game_state[table], room=table)
-  print game_state
+    GAME_STATE[table] = INITIAL_GAME_STATE_FOR_TABLE.copy()
+    sio.emit('game_state_update', GAME_STATE[table], room=table)
+  print GAME_STATE
 
 @sio.on('submit')
 def submit(sid, data):
   print("answer", data)
   puzzle, answer = [data.get(key) for key in ['puzzle', 'answer']]
   # TODO: error gracefully if no puzzle or answer
-  correct = answer == answers.get(int(puzzle))
+  correct = answer == ANSWERS.get(int(puzzle))
 
   if correct:
-    table = clients[sid]
+    table = CLIENTS[sid]
     # TODO: update game_state
-    sio.emit('game_state_update', game_state[table], room=table)
+    sio.emit('game_state_update', GAME_STATE[table], room=table)
 
   response = {
     'correct': correct,
@@ -65,8 +77,47 @@ def submit(sid, data):
 @sio.on('disconnect')
 def disconnect(sid):
   print('disconnect ', sid)
-  if sid in clients:
-    clients.pop(sid)
+  if sid in CLIENTS:
+    # Delete from our clients
+    table = CLIENTS.pop(sid)
+
+    # Puzzle 5 cleanup
+    if sid in GAME_STATE[table][5]['segments']:
+      del GAME_STATE[table][5]['segments'][sid]
+
+@sio.on('puzzle5_join')
+def puzzle5_join(sid, data):
+  print('puzzle5_join', sid)
+  table = CLIENTS[sid]
+  puzzle5 = GAME_STATE[table][5]
+
+  # This is the first person joining
+  if puzzle5['total_segments'] == 0:
+    friends = [key for key in CLIENTS if CLIENTS[key] == table]
+    random.shuffle(friends)
+    puzzle5['total_segments'] = len(friends)
+    for i in range(len(friends)):
+      puzzle5['segments'][friends[i]] = i
+
+  segments = puzzle5['segments']
+  if sid in segments:
+    # Return your assigned segment
+    switch_index = segments[sid]
+  else:
+    if len(segments.values()) == puzzle5['total_segments']:
+      # All indexes are taken, you are a spectator
+      switch_index = -1
+    else:
+      # Pick an unused index
+      unused = set(range(puzzle5['total_segments'])) - set(segments.values())
+      switch_index = random.choice(list(unused))
+      # Claim the index by setting it in segments
+      segments[sid] = switch_index
+  response = {
+    'switch_index': switch_index,
+    'total': puzzle5['total_segments'],
+  }
+  sio.emit('puzzle5_join_response', response, room=sid)
 
 if __name__ == '__main__':
   app = socketio.WSGIApp(sio, flask_app)


### PR DESCRIPTION
![screenshot from 2018-12-29 16-49-27](https://user-images.githubusercontent.com/614205/50543317-d0062700-0b89-11e9-9340-73f087d665d3.png)
Adds the initial version of the server side sync code. When the first person joins the puzzle, the server locks the number of switches to the current number of players in the table. If you navigate away and back, you should receive the same switch (denoted by the Y in the screenshot). A new player will see all X's when there's no available switch (ie in a 3 person table, someone enters Puzzle5 and locks the number of players to 3, everyone enters Puzzle5 which assigns them each a switch, player 4 joins and has no available switches and sees all X's). When any number of player leaves, the next new player that doesn't have an assigned switch will get one of those switches.

Added a simple Puzzle5 frontend component, but that can just be a starting point.

Still need to handle what happens when the players interact with the switches.
Also found a bug where refresh won't rejoin the table saved in your cookies. Will fix that in another PR.