### PR TITLE
fix unmount warning

### DIFF
--- a/frontend/components/puzzle.jsx
+++ b/frontend/components/puzzle.jsx
@@ -45,14 +45,24 @@ export default class Puzzle extends React.Component {
     super(props);
     const { socket } = props;
     this.resetCorrect = this.resetCorrect.bind(this);
-    socket.on('submit_response', (data) => {
-      this.setState({ correct: data.correct });
-    });
+    this.submitResponseHandler = this.submitResponseHandler.bind(this);
+    socket.on('submit_response', this.submitResponseHandler);
 
     this.state = {
       correct: null,
     };
   }
+
+  componentWillUnmount() {
+    const { socket } = this.props;
+
+    socket.removeListener('submit_response', this.submitResponseHandler);
+  }
+
+  submitResponseHandler(data) {
+    this.setState({ correct: data.correct });
+  };
+
   resetCorrect() {
     this.setState({ correct : null });
   }

--- a/server/server.py
+++ b/server/server.py
@@ -102,15 +102,15 @@ def submit(sid, data):
   # TODO: error gracefully if no puzzle or answer
   correct = answer == ANSWERS.get(int(puzzle))
 
-  if correct:
-    table = CLIENTS[sid]
-    GAME_STATE[table][int(puzzle)]['solved'] = True
-    send_game_state(table=table)
-
   response = {
     'correct': correct,
   }
   sio.emit('submit_response', response, room=sid)
+
+  if correct:
+    table = CLIENTS[sid]
+    GAME_STATE[table][int(puzzle)]['solved'] = True
+    send_game_state(table=table)
 
 @sio.on('disconnect')
 def disconnect(sid):


### PR DESCRIPTION
this fixes that memory leak warning we keep seeing in the console.

there are two parts to this. First is that the server would send the game state update before it sends the response. This forces the puzzle to change from the game state update before it can respond to the submit response. Then, when the submit response comes in, the listener responds to it, but the puzzle has already been unmounted, so the setState call is a no-op.

This PR changes the server to send the submit response first before submitting the game state update. Of course, it's still possible that we run into the same problem if there's an issue with emits coming in a different order, but this shouldn't happen very often. This PR also removes the listener on unmount so the listener won't execute if we do get a stray submit response back from the server.