### PR TITLE
fix state copy bug

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -5,6 +5,7 @@ import socketio
 import eventlet
 import eventlet.wsgi
 import random
+from copy import deepcopy
 from datetime import datetime
 from string import ascii_lowercase as alphabet
 from flask import Flask, render_template, jsonify, request, send_from_directory
@@ -92,7 +93,7 @@ def join(sid, data):
     sio.emit('player_joined', {}, room=table, skip_sid=sid)
   else:
     # this is the first person to join this table
-    GAME_STATE[table] = INITIAL_GAME_STATE_FOR_TABLE.copy()
+    GAME_STATE[table] = deepcopy(INITIAL_GAME_STATE_FOR_TABLE)
     GAME_STATE[table]['start_time'] = datetime.now().isoformat()
   send_game_state(sid=sid)
   print GAME_STATE


### PR DESCRIPTION
same issue that we've discussed before, where the reference to an object was copied, so changes to that object would reflect elsewhere. This change does a deepcopy so we should have a brand new copy of the game state for each table.

fixes https://github.com/iamsammak/thehuntgame/issues/82