### PR TITLE
reduce bundle size by only importing icons we need

### DIFF
--- a/frontend/components/admin.jsx
+++ b/frontend/components/admin.jsx
@@ -3,10 +3,13 @@ import io from 'socket.io-client';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
+import faCheck from '@fortawesome/free-solid-svg-icons/faCheck';
+import faTimes from '@fortawesome/free-solid-svg-icons/faTimes';
 
-library.add(fas);
-
+library.add(
+  faCheck,
+  faTimes,
+);
 
 const CheckIcon = styled(FontAwesomeIcon).attrs( props => ({
   icon: props.solved ? 'check' : 'times',

--- a/frontend/components/root.jsx
+++ b/frontend/components/root.jsx
@@ -3,11 +3,41 @@ import styled from 'styled-components';
 import { HashRouter } from 'react-router-dom';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
+import faTimes from '@fortawesome/free-solid-svg-icons/faTimes';
+import faArrowLeft from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+import faArrowRight from '@fortawesome/free-solid-svg-icons/faArrowRight';
+import faArrowUp from '@fortawesome/free-solid-svg-icons/faArrowUp';
+import faArrowDown from '@fortawesome/free-solid-svg-icons/faArrowDown';
+import faStar from '@fortawesome/free-solid-svg-icons/faStar';
+import faGem from '@fortawesome/free-solid-svg-icons/faGem';
+import faChevronLeft from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import faChevronRight from '@fortawesome/free-solid-svg-icons/faChevronRight';
+import faChevronUp from '@fortawesome/free-solid-svg-icons/faChevronUp';
+import faChevronDown from '@fortawesome/free-solid-svg-icons/faChevronDown';
+import faChevronCircleLeft from '@fortawesome/free-solid-svg-icons/faChevronCircleLeft';
+import faChevronCircleRight from '@fortawesome/free-solid-svg-icons/faChevronCircleRight';
+import faChevronCircleUp from '@fortawesome/free-solid-svg-icons/faChevronCircleUp';
+import faChevronCircleDown from '@fortawesome/free-solid-svg-icons/faChevronCircleDown';
 
 import App from './app';
 
-library.add(fas);
+library.add(
+  faTimes,
+  faArrowLeft,
+  faArrowRight,
+  faArrowUp,
+  faArrowDown,
+  faStar,
+  faGem,
+  faChevronLeft,
+  faChevronRight,
+  faChevronUp,
+  faChevronDown,
+  faChevronCircleLeft,
+  faChevronCircleRight,
+  faChevronCircleUp,
+  faChevronCircleDown,
+);
 
 const AppContainer = styled.div`
   display: flex;


### PR DESCRIPTION
went from 
```
  ./frontend/admin-bundle.js (855 KiB)
  ./frontend/hunt-bundle.js (1.01 MiB)
```
to
```
  ./frontend/admin-bundle.js (274 KiB)
  ./frontend/hunt-bundle.js (470 KiB)
```
unfortunately, this will mean we have to import new icons we use individually