### PR TITLE
add load testing script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-cli": "^3.1.2"
   },
   "devDependencies": {
+    "artillery": "^1.6.0-27",
     "babel-eslint": "^10.0.1",
     "css-loader": "^2.0.0",
     "dotenv": "^6.2.0",

--- a/server/load_test.js
+++ b/server/load_test.js
@@ -1,0 +1,68 @@
+const people = ["matt", "tim", "jay", "ryan", "kristi", "erica", "maryann", "helena"];
+const answers = ['getaway', 'secret', 'honeymoon', [false, false, true, true, false, false, false, false, true, false], 'devotion', '', [false, true, true, false, true, false, false, true, true, false], ''];
+const state = {};
+
+// an integer between 0 and PAUSE_BETWEEN_EVERY_ACTION_MAX is how long a user will
+// do nothing after each action
+const PAUSE_BETWEEN_EVERY_ACTION_MAX = 10;
+// 1 / PROB_OF_CORRECT_ANSWER is the probability the user will get the answer right
+const PROB_OF_CORRECT_ANSWER = 50;
+
+// [min, max)
+function generateRandomNumber(min, max) {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+function genRandomThink(context, eventEmitter, done) {
+  context.vars.think = generateRandomNumber(0, PAUSE_BETWEEN_EVERY_ACTION_MAX);
+  return done();
+}
+
+function genRandomPerson(context, eventEmitter, done) {
+  const index = generateRandomNumber(0, people.length);
+  context.vars.person = people[index];
+  return done();
+}
+
+// We can get into weird situations where we submit an answer
+// before we start it, but it's probably not a big deal.
+function genRandomAnswer(context, eventEmitter, done) {
+  const index = generateRandomNumber(0, PROB_OF_CORRECT_ANSWER);
+  const table = context.vars.table;
+  const puzzle = state[table];
+  context.vars.puzzle = puzzle;
+  if (index === 1) {
+    context.vars.answer = answers[puzzle - 1];
+    // Next puzzle
+    state[table] += 1;
+  } else {
+    context.vars.answer = 'wrong';
+  }
+  return done();
+}
+
+function joinTable(context, eventEmitter, done) {
+  const table = generateRandomNumber(0, 30);
+  context.vars.table = table;
+  if (state[table] === undefined) {
+    state[table] = 1;
+  }
+  context.vars.puzzle = state[table];
+  return done();
+}
+
+function updateContext(context, eventEmitter, done) {
+  const table = context.vars.table;
+  if (state[table] !== undefined) {
+    context.vars.puzzle = state[table];
+  }
+  return done();
+}
+
+module.exports = {
+  genRandomAnswer,
+  genRandomPerson,
+  genRandomThink,
+  joinTable,
+  updateContext,
+};

--- a/server/load_test.yml
+++ b/server/load_test.yml
@@ -1,0 +1,32 @@
+config:
+  target: "http://localhost:8000"
+  phases:
+    - duration: 10
+      arrivalCount: 200
+    - pause: 300
+  environments:
+    development:
+      target: "http://localhost:8000"
+    production:
+      target: "http://christinechris.thinkingalaud.com"
+  processor: "./load_test.js"
+scenarios:
+  - engine: "socketio"
+    flow:
+      - function: "joinTable"
+      - emit:
+          channel: "join"
+          data: { "table": "{{ table }}" }
+      - loop:
+          - function: "updateContext"
+          - function: "genRandomThink"
+          - think: "{{ think }}"
+          - function: "genRandomPerson"
+          - emit:
+              channel: "person_visit"
+              data: { "personId": "{{ person }}" }
+          - function: "genRandomAnswer"
+          - emit:
+              channel: "submit"
+              data: { "puzzle": "{{ puzzle }}", "answer": "{{ answer }}" }
+        count: 50


### PR DESCRIPTION
fixes https://github.com/iamsammak/thehuntgame/issues/161
script to run performance test
* emulates a user by joining a table, then doing the following 50 times:
  * waits for a random period of time (between 0 and 10 seconds)
  * navigates to a random person's page
  * submit an answer (1 in 50 chance that the user will submit the correct answer and move onto the next puzzle
* spins up 200 users in 10 seconds, then lets them run for 5 minutes.

tested on production server, doesn't look super good:
![Screenshot from 2019-04-13 21-23-56](https://user-images.githubusercontent.com/614205/56088293-7c66d300-5e32-11e9-9615-ea349950912e.png)
